### PR TITLE
BYTE型をGLubyte型に変更した

### DIFF
--- a/Players/Cocos2d-x_v2/SS5Player.cpp
+++ b/Players/Cocos2d-x_v2/SS5Player.cpp
@@ -1524,7 +1524,7 @@ void Player::setFrame(int frameNo)
 		
 		
 		//頂点情報の取得
-		cocos2d::ccColor4B color4 = { 0xff, 0xff, 0xff, (BYTE)opacity };
+		cocos2d::ccColor4B color4 = { 0xff, 0xff, 0xff, (GLubyte)opacity };
 		quad.tl.colors =
 		quad.tr.colors =
 		quad.bl.colors =

--- a/Players/Cocos2d-x_v3/SS5Player.cpp
+++ b/Players/Cocos2d-x_v3/SS5Player.cpp
@@ -1462,7 +1462,7 @@ void Player::setFrame(int frameNo)
 		
 		
 		//頂点情報の取得
-		cocos2d::Color4B color4 = { 0xff, 0xff, 0xff, (BYTE)opacity };
+		cocos2d::Color4B color4 = { 0xff, 0xff, 0xff, (GLubyte)opacity };
 		quad.tl.colors =
 		quad.tr.colors =
 		quad.bl.colors =


### PR DESCRIPTION
SS5Playerの一部でDirectXのBYTE型が利用されておりました。

そのため、Mac環境でのビルドが通らなかったので、GLubyteに変更いたしました。
