### PR TITLE
Update : 未初期化変数の初期化

### DIFF
--- a/Common/Animator/ssplayer_PartState.cpp
+++ b/Common/Animator/ssplayer_PartState.cpp
@@ -2,7 +2,7 @@
 #include "ssplayer_animedecode.h"
 #include "ssplayer_PartState.h"
 
-SsPartState::SsPartState() : refAnime(0) {init();}
+SsPartState::SsPartState() : refAnime(0), index(-1), parent(nullptr), noCells(false), alphaBlendType(SsBlendType::invalid) {init();}
 
 SsPartState::~SsPartState(){
 	destroy();

--- a/Common/Loader/ssloader_ssae.h
+++ b/Common/Loader/ssloader_ssae.h
@@ -27,6 +27,7 @@ public:
 		SSAR_DECLARE( frameCount );
 		SSAR_DECLARE( canvasSize );
 		SSAR_DECLARE( pivot );
+		SSAR_DECLARE_ENUM(sortMode);
 	}
 };
 


### PR DESCRIPTION
同じコンバータを利用しても違う結果になる場合の修正となります。

また、
https://github.com/SpriteStudio/SpriteStudio5-SDK/blob/master/Build/Converter/main.cpp#L968
こちらを固定化していただくことで、win/mac/linux で同一ソースでビルドされたコンバータから同一バイナリを出力することが可能となります。
